### PR TITLE
Bump iTextSharp to 3.4.22

### DIFF
--- a/src/EasyPDF/Shane32.EasyPDF.csproj
+++ b/src/EasyPDF/Shane32.EasyPDF.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="iTextSharp.LGPLv2.Core" Version="3.4.18" />
+    <PackageReference Include="iTextSharp.LGPLv2.Core" Version="3.4.22" />
     <PackageReference Include="QRCoder" Version="1.5.1" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
   </ItemGroup>

--- a/src/EasyPDF/Shane32.EasyPDF.csproj
+++ b/src/EasyPDF/Shane32.EasyPDF.csproj
@@ -14,6 +14,6 @@
   <ItemGroup>
     <PackageReference Include="iTextSharp.LGPLv2.Core" Version="3.4.22" />
     <PackageReference Include="QRCoder" Version="1.5.1" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="7.0.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
iTextSharp 3.4.22 adds a strong name on the assembly.  So prior versions of EasyPDF cannot use 3.4.22 or newer.